### PR TITLE
chore(landing): update Python landing copy from "Axon" to "AxonSDK"

### DIFF
--- a/py/index.html
+++ b/py/index.html
@@ -3,9 +3,9 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Axon — Route AI workloads to any edge. Python-first.</title>
+  <title>AxonSDK — Route AI workloads to any edge. Python-first.</title>
   <meta name="description" content="The Python SDK for edge AI workload routing. Deploy inference to GPU clusters, TEE nodes, and major cloud providers — automatically routed to the fastest, cheapest option. One interface. Zero lock-in." />
-  <meta property="og:title" content="Axon Python SDK — Route AI to the edge" />
+  <meta property="og:title" content="AxonSDK for Python — Route AI to the edge" />
   <meta property="og:description" content="pip install axon and your AI workloads route across io.net, Akash, AWS, Cloudflare and more. OpenAI-compatible. Async-native. Provider-agnostic." />
   <meta property="og:url" content="https://axon.dev" />
   <meta property="og:type" content="website" />
@@ -305,7 +305,7 @@
 
 <!-- ── Nav ──────────────────────────────────────────────────────────────── -->
 <nav>
-  <div class="nav-logo">⚡ <span>Axon</span><span class="py-badge">Python</span></div>
+  <div class="nav-logo">⚡ <span>AxonSDK</span><span class="py-badge">Python</span></div>
   <div class="nav-links">
     <a href="#quickstart">Quick start</a>
     <a href="#providers">Providers</a>
@@ -322,7 +322,7 @@
   <div class="badge">Open Source · v0.1.0 · Python 3.11+ · 10 Providers · Async-native</div>
   <h1>Route AI workloads<br/>to <em>any edge.</em></h1>
   <p>Deploy inference to GPU clusters, TEE nodes, and major cloud providers — all through one async Python interface. No lock-in. No rewriting.</p>
-  <p style="font-size:0.9rem;color:var(--muted);margin-top:0.75rem;max-width:520px;margin-left:auto;margin-right:auto;">Axon is to edge compute what <code style="color:var(--accent)">httpx</code> is to HTTP — one client, any backend.</p>
+  <p style="font-size:0.9rem;color:var(--muted);margin-top:0.75rem;max-width:520px;margin-left:auto;margin-right:auto;">AxonSDK is to edge compute what <code style="color:var(--accent)">httpx</code> is to HTTP — one client, any backend.</p>
   <div class="hero-ctas">
     <a class="btn-primary" href="#quickstart">Get started →</a>
     <a class="btn-secondary" href="https://github.com/deyzho/axon" target="_blank">View on GitHub</a>
@@ -356,7 +356,7 @@
         <div class="section-label">OpenAI-compatible · axon</div>
         <h2 class="section-title" style="margin-bottom:0.75rem;">From OpenAI to the edge<br/>in two lines of Python</h2>
         <p style="color:var(--muted);font-size:1rem;margin-bottom:1.5rem;">
-          Your existing OpenAI SDK code works unchanged. Swap the <code style="color:var(--accent)">base_url</code> and <code style="color:var(--accent)">api_key</code> — Axon routes requests automatically to the cheapest available provider across io.net, Akash, Acurast, AWS and more.
+          Your existing OpenAI SDK code works unchanged. Swap the <code style="color:var(--accent)">base_url</code> and <code style="color:var(--accent)">api_key</code> — AxonSDK routes requests automatically to the cheapest available provider across io.net, Akash, Acurast, AWS and more.
         </p>
         <ul style="list-style:none;display:flex;flex-direction:column;gap:0.6rem;margin-bottom:1.75rem;">
           <li style="display:flex;gap:0.75rem;font-size:0.9rem;color:var(--muted)"><span style="color:var(--accent);font-weight:700;">✓</span> Drop-in with the <code style="color:var(--accent);font-size:.85em">openai</code> Python package, LangChain, LlamaIndex, DSPy</li>
@@ -477,7 +477,7 @@ response = <span class="kw">await</span> client.chat.completions.<span class="fn
   <div class="section-inner">
     <div class="section-label">Providers</div>
     <h2 class="section-title">One interface, any network</h2>
-    <p class="section-sub">Deploy to GPU clusters or major cloud platforms without changing your code. Axon routes to the fastest, cheapest available option.</p>
+    <p class="section-sub">Deploy to GPU clusters or major cloud platforms without changing your code. AxonSDK routes to the fastest, cheapest available option.</p>
 
     <p style="font-weight:600;font-size:.85rem;text-transform:uppercase;letter-spacing:.08em;color:var(--muted);margin-bottom:1rem;">Edge &amp; Private compute</p>
     <div class="provider-grid" style="margin-bottom:2.75rem;">
@@ -620,7 +620,7 @@ response = <span class="kw">await</span> client.chat.completions.<span class="fn
         <div class="step">
           <div class="step-num">1</div>
           <div class="step-content">
-            <h4>Install Axon</h4>
+            <h4>Install AxonSDK</h4>
             <p>Core install covers all edge &amp; cloud providers that use only <code style="color:var(--accent);font-size:.85em">httpx</code>. Add optional extras for AWS, GCP, or Azure SDKs.</p>
           </div>
         </div>
@@ -635,7 +635,7 @@ response = <span class="kw">await</span> client.chat.completions.<span class="fn
           <div class="step-num">3</div>
           <div class="step-content">
             <h4>Deploy your workload</h4>
-            <p>Point Axon at your Python or Node.js entry point. It handles bundling, upload, and registration automatically.</p>
+            <p>Point AxonSDK at your Python or Node.js entry point. It handles bundling, upload, and registration automatically.</p>
           </div>
         </div>
         <div class="step">
@@ -970,7 +970,7 @@ client.<span class="fn">onMessage</span>((msg) => {
     <a href="https://pypi.org/project/axonsdk-py" target="_blank">PyPI</a>
     <a href="https://github.com/deyzho/axon/blob/master/LICENSE" target="_blank">Apache-2.0</a>
   </div>
-  <p>Axon · Provider-agnostic edge AI routing · Built with Python 3.11+</p>
+  <p>AxonSDK · Provider-agnostic edge AI routing · Built with Python 3.11+</p>
 </footer>
 
 <script>


### PR DESCRIPTION
## Summary

- Replace bare "Axon" with "AxonSDK" in user-facing copy on the Python landing (`py.axonsdk.dev`, `py/index.html`). The bare name conflicts with an established unrelated company/product, so the 2026-04 rebrand standardized on "AxonSDK".
- 9 replacements across `py/index.html`: `<title>`, `og:title` (reshaped "Axon Python SDK" → "AxonSDK for Python" to avoid "SDK SDK"), nav logo, hero sub-paragraph, OpenAI-swap section blurb, providers section-sub, "Install Axon" step heading, "Point Axon at your…" deploy step, and the footer tagline.
- Follows [axon-ts#8](https://github.com/deyzho/axon-ts/pull/8) which applied the same treatment to the TS landing.

## Out of scope / intentionally not touched

- API symbols: `AxonClient`, `AxonRouter` (class + `<section-label>` + in-prose reference), `IAxonProvider`, `CircuitBreaker`.
- The in-`<pre>` Python comment `# ── After: Axon edge routing ─────────────────` — it lives inside a code snippet, and the rebrand rule is to leave snippets alone.
- Lowercase `axon` package/module references (`pip install axon`, `from axon import`, `from axon.router import`, `· axon` section label) — these shadow the Python import/module name.
- `AXON_SECRET_KEY` env var name.
- Package/subdomain strings — already `axonsdk-py` / `axonsdk.dev`.

## Test plan

- [ ] Visually inspect `py/index.html` rendered locally / in preview — confirm nav logo, hero tagline, section copy, step headings, and footer all say "AxonSDK"
- [ ] Verify the `<title>` and OG/Twitter meta tags render correctly when the page is shared
- [ ] Spot-check all code snippets still show the original API symbols and module imports unchanged
- [ ] Confirm `py.axonsdk.dev` serves the updated page after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)