### PR TITLE
chore: tidy phonixsdk leftovers and clarify install-vs-import in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ pip install "axonsdk-py[azure]"     # + azure-identity + azure-mgmt-containerins
 pip install "axonsdk-py[all]"       # everything
 ```
 
+> **Note:** Install as `axonsdk-py`, import as `axon`.
+>
+> ```python
+> from axon import AxonClient, AxonRouter
+> ```
+>
+> (The PyPI distribution name differs from the import name — same pattern as `beautifulsoup4` → `from bs4 import`.)
+
 > **Why `axonsdk-py` instead of `axonsdk`?** The `axon`, `axonpy`, and `axon-sdk` names on PyPI are held by unrelated projects, and `axonsdk` is blocked by PyPI's name-similarity rule. `axonsdk-py` mirrors the `axon-ts` repo naming convention (`-py` for Python, `-ts` for TypeScript) while the import path stays `import axon` unchanged.
 
 ---

--- a/README.md
+++ b/README.md
@@ -322,12 +322,12 @@ Axon is the **Python** compute routing SDK. If you're building with **TypeScript
 
 | Package | Description |
 |---|---|
-| [`@phonixsdk/sdk`](https://github.com/deyzho/phonixsdk) | TypeScript SDK — same providers, same routing strategies |
-| [`@phonixsdk/mobile`](https://github.com/deyzho/phonixsdk) | React Native / Expo SDK for iOS & Android |
-| [`@phonixsdk/cli`](https://github.com/deyzho/phonixsdk) | CLI — `axon init`, `axon deploy`, `axon status` |
-| [`@phonixsdk/inference`](https://github.com/deyzho/phonixsdk) | OpenAI-compatible inference handler for Next.js |
+| [`@axonsdk/sdk`](https://github.com/deyzho/axon-ts) | TypeScript SDK — same providers, same routing strategies |
+| [`@axonsdk/mobile`](https://github.com/deyzho/axon-ts) | React Native / Expo SDK for iOS & Android |
+| [`@axonsdk/cli`](https://github.com/deyzho/axon-ts) | CLI — `axon init`, `axon deploy`, `axon status` |
+| [`@axonsdk/inference`](https://github.com/deyzho/axon-ts) | OpenAI-compatible inference handler for Next.js |
 
-**[phonixsdk.dev](https://phonixsdk.dev)** — full documentation for the TypeScript ecosystem.
+**[axonsdk.dev](https://axonsdk.dev)** — full documentation for the TypeScript ecosystem.
 
 ---
 

--- a/src/axon/inference/handler.py
+++ b/src/axon/inference/handler.py
@@ -117,7 +117,7 @@ def create_inference_app(secret_key: str, **kwargs: Any) -> FastAPI:
             {
                 "id": model_id,
                 "object": "model",
-                "owned_by": "phonixsdk",
+                "owned_by": "axonsdk",
                 "description": info["description"],
                 "hardware": info["hardware"],
                 "provider": info["provider"],


### PR DESCRIPTION
## Summary

Diligence-readiness cleanup on the Python repo — resolves three separate inconsistencies left over from the phonix → AxonSDK rebrand:

1. **Stale `@phonixsdk/*` refs in the README `## Ecosystem` section.** The TypeScript ecosystem table and the companion-site link still pointed at `@phonixsdk/*` packages and `phonixsdk.dev`. Updated to `@axonsdk/*` with `axonsdk.dev`; all four TS package links now point at `deyzho/axon-ts`.
2. **Stale `owned_by: \"phonixsdk\"` string in the OpenAI-compatible `/v1/models` response.** `src/axon/inference/handler.py:120` was still returning the old brand as model ownership metadata. Switched to `\"axonsdk\"`. No test asserts on this field, so this is a surface-only change to the live response body.
3. **Ambiguity around install name vs import name.** Added a short callout in the `## Install` section showing `pip install axonsdk-py` alongside `from axon import AxonClient, AxonRouter`, and calling out that this mirrors the `beautifulsoup4` → `from bs4 import` pattern. The existing `Why axonsdk-py instead of axonsdk?` note is preserved — it answers a different question (why the `-py` suffix) and reads fine alongside the new note.

## Out of scope

- `axonsdk-py` distribution name stays unchanged — a related cleanup task proposed renaming to `axonsdk`, but the existing README rationale still holds: `axonsdk` is blocked by PyPI's name-similarity rule.
- `pyproject.toml` verified clean (`name = \"axonsdk-py\"`, homepage/docs point at `axonsdk.dev`, CLI entry point `axon`). No change needed.
- `[![PyPI]](...)` badge already points at the GitHub support issues URL rather than a 404 PyPI project URL. Verified, no change needed.

## Final sanity check

```
$ grep -rni phonix --exclude-dir=.git .
# (zero results)
```

## Test plan

- [ ] CI green on the branch
- [ ] Read the `## Ecosystem` section top-to-bottom — links resolve to `deyzho/axon-ts` and `axonsdk.dev`
- [ ] Read the `## Install` section — the new note reads naturally alongside the existing `Why axonsdk-py?` callout
- [ ] Spot-check the `/v1/models` response body in a manual smoke test (or unit test if one exists for the handler) — confirms `owned_by: axonsdk`