### PR TITLE
fix: update stale og:url on Python landing from axon.dev to py.axonsdk.dev

### DIFF
--- a/py/index.html
+++ b/py/index.html
@@ -7,7 +7,7 @@
   <meta name="description" content="The Python SDK for edge AI workload routing. Deploy inference to GPU clusters, TEE nodes, and major cloud providers — automatically routed to the fastest, cheapest option. One interface. Zero lock-in." />
   <meta property="og:title" content="AxonSDK for Python — Route AI to the edge" />
   <meta property="og:description" content="pip install axon and your AI workloads route across io.net, Akash, AWS, Cloudflare and more. OpenAI-compatible. Async-native. Provider-agnostic." />
-  <meta property="og:url" content="https://axon.dev" />
+  <meta property="og:url" content="https://py.axonsdk.dev" />
   <meta property="og:type" content="website" />
   <meta name="twitter:card" content="summary_large_image" />
   <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>⚡</text></svg>" />


### PR DESCRIPTION
One-line fix for the Open Graph canonical URL on the Python landing (py.axonsdk.dev). Same issue as the TS landing fix — `og:url` was still pointing at the pre-rebrand `axon.dev`; updated to `https://py.axonsdk.dev` to match the serving subdomain.