### PR TITLE
fix: use AxonSDK brand name in CLI --help banner

### DIFF
--- a/src/axon/cli/__init__.py
+++ b/src/axon/cli/__init__.py
@@ -1,1 +1,1 @@
-"""Axon CLI — command-line tool for managing edge AI deployments."""
+"""AxonSDK CLI — command-line tool for managing edge AI deployments."""

--- a/src/axon/cli/main.py
+++ b/src/axon/cli/main.py
@@ -1,4 +1,4 @@
-"""Axon CLI built with Typer."""
+"""AxonSDK CLI built with Typer."""
 
 from __future__ import annotations
 
@@ -13,7 +13,7 @@ from rich.table import Table
 
 app = typer.Typer(
     name="axon",
-    help="Axon — Provider-agnostic edge compute SDK for AI workload routing",
+    help="AxonSDK — Provider-agnostic edge compute SDK for AI workload routing",
     add_completion=False,
 )
 console = Console()


### PR DESCRIPTION
## Summary

Spotted during the fresh-clone installability smoke test: running `axon --help` on a freshly-installed `axonsdk-py` shows a banner that reads `Axon — Provider-agnostic edge compute SDK for AI workload routing`. Per the standing brand rule (always write "AxonSDK", not bare "Axon", because another company owns that name), this should read `AxonSDK —`.

**Changes:**

- `src/axon/cli/main.py`: updated the `typer.Typer(help=...)` string from `"Axon — ..."` to `"AxonSDK — ..."` — this is the banner users see on `axon --help`.
- `src/axon/cli/main.py`: updated the module docstring from `"""Axon CLI built with Typer."""` to `"""AxonSDK CLI built with Typer."""` — keeps the brand consistent in any docstring-driven tooling.
- `src/axon/cli/__init__.py`: updated the module docstring from `"""Axon CLI — ..."""` to `"""AxonSDK CLI — ..."""` — same rationale.

## Verification

After merge + `pip install -e .`, `axon --help` should show:

```
Usage: axon [OPTIONS] COMMAND [ARGS]...

  AxonSDK — Provider-agnostic edge compute SDK for AI workload routing
```

(Noting `axon` stays as the CLI command name — only the displayed brand string is updated.)

## Two commits

The branch has a main commit plus a follow-up that caught the `__init__.py` docstring I missed in the first pass. Squash-merge flattens them into one on master.