### PR TITLE
chore: pre-launch hardening (weeks 1-3) — v0.1.12, brand, community, pip-audit, roadmap

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,82 @@
+name: Bug report
+description: Report a bug in axonsdk-py
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to report a bug. A clear repro makes fixes land faster.
+
+        For security issues, do **not** open an issue — follow the process in [SECURITY.md](../SECURITY.md).
+  - type: input
+    id: version
+    attributes:
+      label: axonsdk-py version
+      description: Output of `pip show axonsdk-py | grep Version`.
+      placeholder: "0.1.12"
+    validations:
+      required: true
+  - type: input
+    id: python
+    attributes:
+      label: Python version
+      placeholder: "3.12.3"
+    validations:
+      required: true
+  - type: input
+    id: platform
+    attributes:
+      label: OS / platform
+      placeholder: "Ubuntu 22.04 / macOS 14.5 / Windows 11"
+    validations:
+      required: true
+  - type: dropdown
+    id: extras
+    attributes:
+      label: Installed extras
+      description: Which optional extras are installed? (from `pip install "axonsdk-py[...]"`)
+      multiple: true
+      options:
+        - "core (no extras)"
+        - "blockchain"
+        - "inference"
+        - "cli"
+        - "aws"
+        - "gcp"
+        - "azure"
+        - "all"
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: Minimal steps or code snippet that reproduces the issue.
+      placeholder: |
+        1. `pip install axonsdk-py==0.1.12`
+        2. Run the following snippet:
+           ```python
+           ...
+           ```
+        3. Observe error: ...
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: Include full stack traces and error messages.
+    validations:
+      required: true
+  - type: textarea
+    id: context
+    attributes:
+      label: Additional context
+      description: Provider in use, deployment target, or anything else that might matter.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,8 +1,8 @@
 blank_issues_enabled: false
 contact_links:
   - name: Security vulnerability
-    url: https://github.com/deyzho/axon/security/policy
+    url: https://github.com/deyzho/axonsdk/security/policy
     about: Report security issues privately per SECURITY.md — do not open a public issue.
   - name: Question or discussion
-    url: https://github.com/deyzho/axon/discussions
+    url: https://github.com/deyzho/axonsdk/discussions
     about: For general questions, ideas, or help using the SDK.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/deyzho/axon/security/policy
+    about: Report security issues privately per SECURITY.md — do not open a public issue.
+  - name: Question or discussion
+    url: https://github.com/deyzho/axon/discussions
+    about: For general questions, ideas, or help using the SDK.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,28 @@
+name: Feature request
+description: Suggest a feature or improvement
+title: "[feature] "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Before filing, please check the [ROADMAP](../ROADMAP.md) and search open issues — the feature may already be planned.
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does this solve?
+      description: Describe the use case. Features motivated by a concrete problem ship faster than nice-to-haves.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: API shape, CLI flag, config option — whatever form the feature would take.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you've tried, including workarounds that don't quite work.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+<!--
+Thanks for contributing to AxonSDK! Please fill out the sections below.
+For small changes (typo, doc fix), a one-line summary is fine.
+-->
+
+## What does this PR do?
+
+<!-- One or two sentences on the change and why. -->
+
+## Checklist
+
+- [ ] Tests added or updated (or explain why not)
+- [ ] `pytest tests/` passes locally
+- [ ] `ruff check src/axon` and `mypy src/axon` pass locally
+- [ ] `CHANGELOG.md` updated
+- [ ] Breaking changes are flagged as **Changed — Breaking** with a **Migration** section in CHANGELOG
+- [ ] Brand name is written as "AxonSDK" (not bare "Axon") in any user-facing copy

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,6 +24,13 @@ jobs:
       - name: Install dependencies
         run: pip install -e ".[dev,blockchain,inference,aws,gcp,azure]"
 
+      - name: Audit dependencies (pip-audit)
+        run: |
+          pip install pip-audit
+          # Freeze deps but skip our own package (not yet on PyPI for lookup).
+          pip freeze --exclude-editable | grep -v "^axonsdk-py" > /tmp/requirements-frozen.txt
+          pip-audit -r /tmp/requirements-frozen.txt --desc --strict
+
       - name: Lint (ruff)
         run: ruff check src/axon
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -80,3 +80,16 @@ jobs:
 
       - name: Publish to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
+
+  release:
+    name: Create GitHub Release
+    needs: publish
+    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.htm
 
 ---
 
+## [0.1.12] — 2026-04-22
+
+### Fixed
+- **Packaging:** `[all]` optional-dependency extra self-referenced the wrong distribution name (`axon[...]` instead of `axonsdk-py[...]`). `pip install "axonsdk-py[all]"` now installs all optional extras correctly. Previously pip would attempt to resolve a separate `axon` package from PyPI.
+- **Version drift:** `axon.__version__` is now read dynamically from the installed package metadata via `importlib.metadata` instead of a hard-coded string, so it can no longer lag behind the `pyproject.toml` version. The 0.1.11 wheel on PyPI reported `__version__ = "0.1.6"` — consumers on 0.1.12+ get the correct version.
+
+### Added
+- **Typing:** `src/axon/py.typed` (PEP 561 marker) — downstream `mypy` and `pyright` now see the public API's type hints instead of falling back to `Any`.
+
+---
+
+## [0.1.11] — 2026-04-20
+
+### Changed
+- **Brand:** AxonSDK consistency pass across CLI `--help` banner, README, and Python landing page. "Axon" (bare) replaced with "AxonSDK" in user-facing copy to disambiguate from the unrelated company of that name.
+- **Landing:** Unified AxonSDK landing at `axonsdk.dev`; Python-specific landing moved to `py.axonsdk.dev`.
+
+### Fixed
+- **Stale brand references:** `@phonixsdk/*` package names replaced with `@axonsdk/*` throughout README cross-references.
+- **OpenAI-compatible endpoint:** removed stale `phonixsdk` `owned_by` value from `/v1/models` response payload.
+- **README install-vs-import:** clarified that the PyPI distribution is `axonsdk-py` while the import name remains `axon` (same pattern as `beautifulsoup4` → `from bs4 import`).
+
+---
+
+## [0.1.10] — 2026-04-19
+
+This is the first version actually published to PyPI. Versions 0.1.0 through 0.1.9 existed as git tags during pre-PyPI development but were never published to the registry.
+
+### Added
+- **PyPI Trusted Publishing:** OIDC-backed release pipeline — no long-lived tokens.
+- **Providers:** Implementation of `COST` routing strategy across all cloud backends.
+- **Security:** 30-day post-close remediation — SSRF protection hardening, LRU rate-limit store, CI hardening (ruff + mypy strict + pytest-cov).
+- **Inference:** Test suite added for the OpenAI-compatible handler; auth and parameter forwarding fixed.
+
+### Changed
+- **PyPI distribution name:** finalised as `axonsdk-py`. `axon`, `axonpy`, `axon-sdk`, and `axonsdk` all failed PyPI's similarity check against existing packages.
+- **README:** CI badge, correct PyPI install name, ecosystem section linking the companion TS monorepo.
+- **SECURITY.md:** updated contact and disclosure timeline.
+
+---
+
 ## [0.1.7] — 2026-04-14
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,10 +79,10 @@ This is the first version actually published to PyPI. Versions 0.1.0 through 0.1
 - **Dependencies:** `eth-account` moved from core to optional `blockchain` extra — install with `pip install axonsdk-py[blockchain]` (required for Akash, Acurast, Fluence, Koii providers)
 - **CI:** `--ignore-missing-imports` flag removed from CI mypy invocation — now configured permanently in `[tool.mypy]`
 - **CI:** `mypy` now reads `ignore_missing_imports = true` from `pyproject.toml`
-- **Project URLs:** Fixed `project.urls` in `pyproject.toml` — `Repository` now correctly points to `deyzho/axon`
+- **Project URLs:** Fixed `project.urls` in `pyproject.toml` — `Repository` now correctly points to `deyzho/axonsdk`
 
 ### Fixed
-- `pyproject.toml` project URLs corrected from `deyzho/axonsdk` to `deyzho/axon`
+- `pyproject.toml` project URLs corrected from `deyzho/axonsdk` to `deyzho/axonsdk`
 
 ---
 
@@ -126,8 +126,8 @@ This is the first version actually published to PyPI. Versions 0.1.0 through 0.1
 
 ---
 
-[0.1.7]: https://github.com/deyzho/axon/compare/v0.1.6...v0.1.7
-[0.1.6]: https://github.com/deyzho/axon/compare/v0.1.5...v0.1.6
-[0.1.5]: https://github.com/deyzho/axon/compare/v0.1.2...v0.1.5
-[0.1.2]: https://github.com/deyzho/axon/compare/v0.1.0...v0.1.2
-[0.1.0]: https://github.com/deyzho/axon/releases/tag/v0.1.0
+[0.1.7]: https://github.com/deyzho/axonsdk/compare/v0.1.6...v0.1.7
+[0.1.6]: https://github.com/deyzho/axonsdk/compare/v0.1.5...v0.1.6
+[0.1.5]: https://github.com/deyzho/axonsdk/compare/v0.1.2...v0.1.5
+[0.1.2]: https://github.com/deyzho/axonsdk/compare/v0.1.0...v0.1.2
+[0.1.0]: https://github.com/deyzho/axonsdk/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-All notable changes to the Axon Python SDK are documented here.
+All notable changes to the AxonSDK Python package are documented here.
 
 The format follows [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,15 @@
+# Code of Conduct
+
+This project follows the [Contributor Covenant v2.1](https://www.contributor-covenant.org/version/2/1/code_of_conduct/) as its code of conduct.
+
+## Reporting
+
+To report unacceptable behavior, contact the project maintainer:
+
+- **Email:** deyzho@me.com
+
+Reports will be reviewed and responded to within 72 hours. All reports are kept confidential.
+
+## Scope
+
+This Code of Conduct applies within all project spaces — GitHub issues, pull requests, discussions, and any other communication channels used by the project — and in public spaces when an individual is representing the project.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to Axon SDK (Python)
+# Contributing to AxonSDK (Python)
 
 Thank you for your interest in contributing! This guide covers everything you need to get started.
 
@@ -175,6 +175,33 @@ class MyProvider(IAxonProvider):
 - **Line length:** 100 characters
 - **Python target:** 3.11+ syntax; use `from __future__ import annotations` in all files
 - **No `# type: ignore`** without a specific error code and comment explaining why
+
+---
+
+## Versioning policy
+
+AxonSDK follows [Semantic Versioning 2.0](https://semver.org/spec/v2.0.0.html). Because the project is pre-1.0, the rules are tighter than a simple reading of SemVer:
+
+- **`0.x.y`** — minor bumps (`0.x.Y`) may contain breaking changes, but every breaking change must be documented. Patch bumps (`0.X.y`) are strictly bug-fix / non-breaking.
+- **`≥1.0`** — breaking changes require a major bump. Deprecations are announced at least one minor version before removal.
+
+### Breaking-change requirements
+
+Every breaking change must:
+
+1. Be listed in `CHANGELOG.md` under a **Changed — Breaking** heading.
+2. Include a **Migration** block with copy-pastable before/after snippets for anything a consumer might actually be doing. Don't make people read source code to upgrade.
+3. Be called out in the GitHub Release notes, not buried in the commit message.
+
+### Release checklist
+
+When preparing a release:
+
+1. Bump `version = "..."` in `pyproject.toml`.
+2. Add a new top-of-file section to `CHANGELOG.md` with the version and date.
+3. Tag `vX.Y.Z` — CI publishes to PyPI via OIDC Trusted Publishing and creates the GitHub Release automatically.
+
+Do **not** manually edit `__version__` in `src/axon/__init__.py` — it is read dynamically from package metadata via `importlib.metadata.version("axonsdk-py")`.
 
 ---
 

--- a/LICENSE
+++ b/LICENSE
@@ -168,7 +168,18 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2026 Axon SDK Contributors
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 AxonSDK Contributors
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Axon SDK
+# AxonSDK (Python)
 
 [![CI](https://github.com/deyzho/axon/actions/workflows/publish.yml/badge.svg)](https://github.com/deyzho/axon/actions/workflows/publish.yml)
 [![PyPI](https://img.shields.io/pypi/v/axonsdk-py?color=f97316)](https://pypi.org/project/axonsdk-py/)
@@ -9,9 +9,9 @@
 
 **One SDK. Any compute. Route AI inference to the fastest, cheapest backend — cloud, edge, or your own infrastructure.**
 
-Axon is a universal AI compute routing layer. Stop rewriting integrations every time you switch providers, hit rate limits, or find a cheaper GPU. Point Axon at any backend — GPU clusters, container clouds, serverless functions, TEE enclaves, or your own servers — and it handles routing, failover, and cost optimisation automatically.
+AxonSDK is a universal AI compute routing layer. Stop rewriting integrations every time you switch providers, hit rate limits, or find a cheaper GPU. Point AxonSDK at any backend — GPU clusters, container clouds, serverless functions, TEE enclaves, or your own servers — and it handles routing, failover, and cost optimisation automatically.
 
-> Axon is to AI compute what httpx is to HTTP — **one client, any backend**.
+> AxonSDK is to AI compute what httpx is to HTTP — **one client, any backend**.
 
 ---
 
@@ -326,7 +326,7 @@ High-impact areas:
 
 ## Ecosystem
 
-Axon is the **Python** compute routing SDK. If you're building with **TypeScript / Node.js**, React Native, or deploying via a CLI, see the companion repositories:
+This is the **Python** AxonSDK. If you're building with **TypeScript / Node.js**, React Native, or deploying via a CLI, see the companion repositories:
 
 | Package | Description |
 |---|---|
@@ -347,4 +347,4 @@ Apache-2.0 — see [LICENSE](./LICENSE).
 
 **[axonsdk.dev](https://axonsdk.dev)** · deyzho@me.com · Apache-2.0
 
-*Axon is not affiliated with io.net, Akash Network, Acurast, Fluence, or Koii. Provider names and trademarks belong to their respective owners.*
+*AxonSDK is not affiliated with io.net, Akash Network, Acurast, Fluence, or Koii. Provider names and trademarks belong to their respective owners.*

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # AxonSDK (Python)
 
-[![CI](https://github.com/deyzho/axon/actions/workflows/publish.yml/badge.svg)](https://github.com/deyzho/axon/actions/workflows/publish.yml)
+[![CI](https://github.com/deyzho/axonsdk/actions/workflows/publish.yml/badge.svg)](https://github.com/deyzho/axonsdk/actions/workflows/publish.yml)
 [![PyPI](https://img.shields.io/pypi/v/axonsdk-py?color=f97316)](https://pypi.org/project/axonsdk-py/)
 [![Python](https://img.shields.io/badge/python-3.11%20|%203.12%20|%203.13-blue)](https://pypi.org/project/axonsdk-py/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](./LICENSE)
 
-**[axonsdk.dev](https://axonsdk.dev) · [PyPI](https://pypi.org/project/axonsdk-py/) · [Roadmap](./ROADMAP.md) · [GitHub](https://github.com/deyzho/axon)**
+**[axonsdk.dev](https://axonsdk.dev) · [PyPI](https://pypi.org/project/axonsdk-py/) · [Roadmap](./ROADMAP.md) · [GitHub](https://github.com/deyzho/axonsdk)**
 
 **One SDK. Any compute. Route AI inference to the fastest, cheapest backend — cloud, edge, or your own infrastructure.**
 
@@ -44,7 +44,7 @@ AxonSDK is a universal AI compute routing layer. Stop rewriting integrations eve
 ## Install
 
 ```bash
-pip install axonsdk-py              # core SDK (mirrors the axon-ts npm packages)
+pip install axonsdk-py              # core SDK (mirrors the axonsdk-ts npm packages)
 pip install "axonsdk-py[inference]" # + FastAPI OpenAI-compatible server
 pip install "axonsdk-py[aws]"       # + boto3
 pip install "axonsdk-py[gcp]"       # + google-auth
@@ -60,7 +60,7 @@ pip install "axonsdk-py[all]"       # everything
 >
 > (The PyPI distribution name differs from the import name — same pattern as `beautifulsoup4` → `from bs4 import`.)
 
-> **Why `axonsdk-py` instead of `axonsdk`?** The `axon`, `axonpy`, and `axon-sdk` names on PyPI are held by unrelated projects, and `axonsdk` is blocked by PyPI's name-similarity rule. `axonsdk-py` mirrors the `axon-ts` repo naming convention (`-py` for Python, `-ts` for TypeScript) while the import path stays `import axon` unchanged.
+> **Why `axonsdk-py` instead of `axonsdk`?** The `axon`, `axonpy`, and `axon-sdk` names on PyPI are held by unrelated projects, and `axonsdk` is blocked by PyPI's name-similarity rule. `axonsdk-py` mirrors the `axonsdk-ts` repo naming convention (`-py` for Python, `-ts` for TypeScript) while the import path stays `import axon` unchanged.
 
 ---
 
@@ -304,7 +304,7 @@ axon/
 ## Development
 
 ```bash
-git clone https://github.com/deyzho/axon.git
+git clone https://github.com/deyzho/axonsdk.git
 cd axon
 pip install -e ".[all,dev]"
 pytest
@@ -330,10 +330,10 @@ This is the **Python** AxonSDK. If you're building with **TypeScript / Node.js**
 
 | Package | Description |
 |---|---|
-| [`@axonsdk/sdk`](https://github.com/deyzho/axon-ts) | TypeScript SDK — same providers, same routing strategies |
-| [`@axonsdk/mobile`](https://github.com/deyzho/axon-ts) | React Native / Expo SDK for iOS & Android |
-| [`@axonsdk/cli`](https://github.com/deyzho/axon-ts) | CLI — `axon init`, `axon deploy`, `axon status` |
-| [`@axonsdk/inference`](https://github.com/deyzho/axon-ts) | OpenAI-compatible inference handler for Next.js |
+| [`@axonsdk/sdk`](https://github.com/deyzho/axonsdk-ts) | TypeScript SDK — same providers, same routing strategies |
+| [`@axonsdk/mobile`](https://github.com/deyzho/axonsdk-ts) | React Native / Expo SDK for iOS & Android |
+| [`@axonsdk/cli`](https://github.com/deyzho/axonsdk-ts) | CLI — `axon init`, `axon deploy`, `axon status` |
+| [`@axonsdk/inference`](https://github.com/deyzho/axonsdk-ts) | OpenAI-compatible inference handler for Next.js |
 
 **[axonsdk.dev](https://axonsdk.dev)** — full documentation for the TypeScript ecosystem.
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Python](https://img.shields.io/badge/python-3.11%20|%203.12%20|%203.13-blue)](https://pypi.org/project/axonsdk-py/)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](./LICENSE)
 
-**[axonsdk.dev](https://axonsdk.dev) · [GitHub](https://github.com/deyzho/axon)**
+**[axonsdk.dev](https://axonsdk.dev) · [PyPI](https://pypi.org/project/axonsdk-py/) · [Roadmap](./ROADMAP.md) · [GitHub](https://github.com/deyzho/axon)**
 
 **One SDK. Any compute. Route AI inference to the fastest, cheapest backend — cloud, edge, or your own infrastructure.**
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -2,7 +2,7 @@
 
 > **Current release:** `axonsdk-py` v0.1.12 — Feature-complete for 10 providers, multi-provider routing, OpenAI-compatible inference, and CLI.
 
-Priorities may shift based on community feedback and provider availability. This roadmap reflects the Python SDK ([`deyzho/axon`](https://github.com/deyzho/axon)). The TypeScript monorepo ([`deyzho/axon-ts`](https://github.com/deyzho/axon-ts)) has its own companion roadmap.
+Priorities may shift based on community feedback and provider availability. This roadmap reflects the Python SDK ([`deyzho/axonsdk`](https://github.com/deyzho/axonsdk)). The TypeScript monorepo ([`deyzho/axonsdk-ts`](https://github.com/deyzho/axonsdk-ts)) has its own companion roadmap.
 
 Dates are targets, not commitments. Each release ships when its acceptance criteria are met.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,90 +1,149 @@
-# Axon SDK (Python) — Roadmap
+# AxonSDK (Python) — Roadmap
 
-> **Current release:** v0.1.6 — Feature-complete for 10 providers, multi-provider routing, OpenAI-compatible inference, and CLI.
+> **Current release:** `axonsdk-py` v0.1.12 — Feature-complete for 10 providers, multi-provider routing, OpenAI-compatible inference, and CLI.
 
----
+Priorities may shift based on community feedback and provider availability. This roadmap reflects the Python SDK ([`deyzho/axon`](https://github.com/deyzho/axon)). The TypeScript monorepo ([`deyzho/axon-ts`](https://github.com/deyzho/axon-ts)) has its own companion roadmap.
 
-## v0.1.x — Current (Alpha)
-
-**Status:** Active maintenance
-
-- [x] All 10 provider implementations (io.net, Akash, Acurast, Fluence, Koii, AWS, GCP, Azure, Cloudflare, Fly.io)
-- [x] `AxonClient` — single-provider facade
-- [x] `AxonRouter` — multi-provider routing with circuit breaker + health monitor
-- [x] OpenAI-compatible inference endpoint (`axon[inference]`)
-- [x] CLI (`axon init`, `axon auth`, `axon deploy`, `axon status`, `axon send`, `axon teardown`)
-- [x] GCP Application Default Credentials (google-auth)
-- [x] Azure OAuth2 client credentials flow
-- [x] AWS boto3 with STS credential validation
-- [x] Exponential backoff retry utility
-- [x] SSRF prevention + DNS rebinding defence (`security.py`)
-- [x] mypy strict mode + ruff linting in CI
-- [x] Apache-2.0 licence, SECURITY.md, responsible disclosure
+Dates are targets, not commitments. Each release ships when its acceptance criteria are met.
 
 ---
 
-## v0.2 — Stability (Q2 2026)
+## v0.1.x — Shipped (2026-04)
 
-**Theme:** Production readiness + observability
+All 10 compute providers implemented; async client + multi-provider router; CLI complete; supply-chain and security hardening landed.
 
-- [ ] `axon logs <deployment_id>` — tail deployment logs
-- [ ] `axon update <deployment_id>` — rolling update an active deployment
+### Providers
+- io.net — GPU clusters (A100, H100, RTX), job submission, HTTP messaging
+- Akash Network — container deployments via SDL, HTTP lease messaging
+- Acurast — TEE messaging and deployment
+- Fluence — serverless P2P messaging
+- Koii — distributed task-node messaging
+- AWS — Lambda, ECS/Fargate via boto3 with STS credential validation
+- Google Cloud — Cloud Run, Cloud Functions via Application Default Credentials
+- Azure — Container Instances, Functions via OAuth2 client credentials
+- Cloudflare Workers — no extra dependencies (httpx is core)
+- Fly.io Machines — no extra dependencies
+
+### SDK + CLI
+- `AxonClient` — single-provider async facade
+- `AxonRouter` — multi-provider routing with circuit breaker and health monitor
+- `axon[inference]` — FastAPI-backed OpenAI-compatible inference endpoint
+- CLI: `axon init`, `axon auth`, `axon deploy`, `axon status`, `axon send`, `axon teardown`
+- Exponential backoff retry utility (`axon.utils.retry.with_retry`)
+
+### Quality and security
+- SSRF prevention + DNS rebinding defence in `security.py` (RFC-1918, loopback, IPv6 link-local, AWS/Azure/GCP IMDS endpoints all blocked)
+- mypy strict across the codebase
+- ruff lint gate in CI
+- Python 3.11 / 3.12 / 3.13 CI matrix
+- Apache-2.0 license with explicit patent grant
+- SECURITY.md with responsible disclosure (48h ack, 90-day deadline)
+- SBOM generation per build (Anchore SPDX)
+- PyPI publish via OIDC Trusted Publishing (no long-lived tokens)
+- PEP 561 `py.typed` marker — downstream mypy/pyright pick up typed imports
+
+---
+
+## v0.2 — Operator UX (target: 2026-Q3)
+
+**Theme: deployed workloads are only useful if operators can see and steer them.**
+
+- [ ] `axon logs <deployment_id>` — tail deployment stdout and runtime events
+- [ ] `axon update <deployment_id>` — redeploy with new code, preserving routing config
 - [ ] `axon stop <deployment_id>` — graceful shutdown without full teardown
-- [ ] Live provider integration tests in CI (sandbox mode for each provider)
-- [ ] Full AWS ECS/Fargate support alongside Lambda
-- [ ] Cloudflare R2 storage binding support
-- [ ] Structured logging (JSON output, configurable log level)
-- [ ] SBOM generation in CI (CycloneDX/SPDX)
-- [ ] Codecov coverage reporting with threshold enforcement
-- [ ] `eth-account` import guard refinement (per-provider lazy import)
+- [ ] Structured logging — JSON output with configurable level, ready for log aggregators
+- [ ] Persistent leases on Akash / io.net — no cold-start latency for long-running jobs
+- [ ] Coverage threshold gate — enforce ≥85% for core modules in CI
+- [ ] Per-provider lazy imports — refine `eth-account` import guard so core install stays slim
+
+### Acceptance criteria for v0.2
+- All three new CLI commands have integration tests against at least one real provider sandbox
+- Coverage gate added to `.github/workflows/publish.yml`
+- Core `pip install axonsdk-py` (no extras) completes in under 20s on a cold cache
 
 ---
 
-## v0.3 — LLM Routing (Q3 2026)
+## v0.3 — Provider trust (target: 2026-Q4)
 
-**Theme:** First-class LLM inference orchestration
+**Theme: enterprise adoption requires proof the integrations actually work.**
 
-- [ ] `AxonLLMClient` — unified LLM client routing across providers
-- [ ] Multi-provider simultaneous deploy (deploy to 3 providers, route traffic to fastest)
-- [ ] Persistent leases on Akash / io.net (no cold-start latency)
+- [ ] Live provider integration tests in CI — run against sandboxes weekly, gated at release (not every PR for cost reasons)
+- [ ] Provider health dashboard at `status.axonsdk.dev` — real latency + error rates, populated from production synthetic workloads
+- [ ] `axon benchmark` — run latency and cost benchmarks across active providers
+- [ ] Template marketplace — browse and install community templates via `axon template install <name>`
+- [ ] LangChain integration — `AxonLLM` class compatible with LangChain chat models
+
+### Acceptance criteria for v0.3
+- At least one real production workload running against each of the 10 providers for ≥30 days
+- Status dashboard publishes uptime and latency history, not just current state
+- Template registry has at least five community-contributed templates
+
+---
+
+## v0.4 — LLM routing (target: 2027-Q1)
+
+**Theme: unify the LLM client layer so the SDK answers "where should this request run" at the model level, not just the compute level.**
+
+- [ ] `AxonLLMClient` — unified LLM client routing across Claude, Gemini, GPT-4, and self-hosted models
+- [ ] Multi-provider simultaneous deploy — deploy to 3 providers, route traffic to fastest
 - [ ] Token-based cost tracking per request
-- [ ] `axon benchmark` — run latency/cost benchmarks across active providers
-- [ ] Model capability registry (which models are available on which providers)
-- [ ] Streaming response aggregation across providers
+- [ ] Model capability registry — which models are available on which providers
+- [ ] Streaming response aggregation across providers (SSE-first, merging headers sensibly)
+- [ ] Ollama local provider — route to local GPU if available, cloud otherwise
 
 ---
 
-## v0.4 — Developer Experience (Q4 2026)
+## v1.0 — Production-ready (target: 2027-Q2)
 
-**Theme:** DX polish and ecosystem integrations
+**Theme: make the 1.0 promise credible. No breaking changes after this without a major bump.**
 
-- [ ] Documentation site (Sphinx + ReadTheDocs or Mintlify)
-- [ ] VS Code extension — provider health, deployment status in status bar
-- [ ] Dashboard web UI — deployment list, live health, cost breakdown
-- [ ] Template marketplace — community-contributed deployment templates
-- [ ] LangChain integration (`AxonLLM` class for LangChain chat models)
-- [ ] Ollama local provider (route to local GPU if available, cloud otherwise)
+### Hard requirements before v1.0 is cut
+1. **All 10 providers have green integration tests** running in CI against provider sandboxes at least weekly
+2. **At least one named reference customer** per cloud (AWS / GCP / Azure / Cloudflare / Fly.io), willing to be quoted
+3. **Deprecation policy in effect**: any API removed between v1.0 and v2.0 must have been marked with `DeprecationWarning` for at least one minor version
+4. **Documentation site live** with full API reference, guides, and a working migration page from `0.x` → `1.0`
+5. **Semver-strict commitment** documented in the README and enforced by CI via a public-API stability check
+6. **Full type coverage** — zero `Any` leaks in the public API of `axon` module (verified via a dedicated mypy run without `ignore_missing_imports` on public interfaces)
+7. **Security audit** — third-party review of the client, router, inference handler, and provider adapters
 
----
-
-## v1.0 — Stable API (2027)
-
-**Theme:** API stability, enterprise-grade
-
-- [ ] Stable public API with semver guarantees
-- [ ] Full API reference documentation (auto-generated)
-- [ ] `AxonClient` connection pooling + keep-alive
-- [ ] Advanced circuit breaker config (per-provider thresholds)
+### The v1.0 release itself
+- [ ] Drop all `0.x.y` deprecated surfaces in a single breaking release
+- [ ] Publish a migration guide covering every renamed or removed API from the `0.x` line
+- [ ] Tag `v1.0.0rc1` at least 4 weeks before `v1.0.0` to give downstream time to test
+- [ ] `AxonClient` connection pooling + HTTP keep-alive tuned for production workloads
+- [ ] Advanced circuit breaker config (per-provider failure thresholds and recovery timeouts)
 - [ ] SLA monitoring and alerting hooks
-- [ ] Enterprise support tier
+
+---
+
+## Long-term (post-1.0, no timeline)
+
+- **Streaming results** — push-based result delivery without polling
+- **Cost analytics** — per-request cost breakdown and optimisation recommendations across providers
+- **SLA routing** — route based on latency SLA targets, not just current metrics
+- **VSCode extension** — provider health, deployment status, one-click deploy from the editor
+- **AxonSDK-native observability** — OpenTelemetry instrumentation across the SDK with per-provider spans
+- **Dashboard web UI** — deployment list, live health, cost breakdown (parity with CLI `axon status`)
 
 ---
 
 ## Not on the roadmap
 
-- **Proprietary cloud** — Axon will remain Apache-2.0 open source
-- **Lock-in** — provider switching will always be a one-line config change
-- **Monolithic architecture** — providers will always be independently installable extras
+- **Proprietary cloud** — AxonSDK will remain Apache-2.0 open source
+- **Vendor lock-in** — provider switching will always be a one-line config change
+- **Monolithic install** — provider integrations will always be independently installable extras
+
+---
+
+## Versioning policy
+
+AxonSDK follows [Semantic Versioning 2.0](https://semver.org/spec/v2.0.0.html). See [`CONTRIBUTING.md`](./CONTRIBUTING.md#versioning-policy) for the full breaking-change policy.
+
+Short version:
+- **`0.x.y`** (current) — minor bumps may contain breaking changes, each documented with a `Changed — Breaking` + `Migration` section in `CHANGELOG.md`.
+- **`≥1.0`** (target 2027-Q2) — breaking changes require a major bump; deprecations are announced one minor version before removal.
+
+The public API is the exported surface of `axon` (as defined by `axon.__all__`), the `axon` CLI commands, the FastAPI handler exported by `axon.inference`, and the provider base class at `axon.providers.base.IAxonProvider`. Breaking changes to any of these will be called out in the CHANGELOG and Release notes.
 
 ---
 

--- a/index.html
+++ b/index.html
@@ -553,8 +553,8 @@ res = <span class="kw">await</span> router.<span class="fn">send</span>(
       <div class="footer-links">
         <a href="https://ts.axonsdk.dev">TypeScript</a>
         <a href="https://py.axonsdk.dev">Python</a>
-        <a href="https://github.com/deyzho/axon-ts" target="_blank" rel="noopener">axon-ts</a>
-        <a href="https://github.com/deyzho/axon" target="_blank" rel="noopener">axon</a>
+        <a href="https://github.com/deyzho/axonsdk-ts" target="_blank" rel="noopener">axon-ts</a>
+        <a href="https://github.com/deyzho/axonsdk" target="_blank" rel="noopener">axon</a>
         <a href="https://status.axonsdk.dev">Status</a>
         <a href="mailto:deyzho@me.com">Contact</a>
       </div>

--- a/py/index.html
+++ b/py/index.html
@@ -312,7 +312,7 @@
     <a href="#router">Router</a>
     <a href="#cli">CLI</a>
     <a href="#features">Features</a>
-    <a href="https://github.com/deyzho/axon" target="_blank">GitHub</a>
+    <a href="https://github.com/deyzho/axonsdk" target="_blank">GitHub</a>
   </div>
   <a class="nav-cta" href="#quickstart">Get started →</a>
 </nav>
@@ -325,7 +325,7 @@
   <p style="font-size:0.9rem;color:var(--muted);margin-top:0.75rem;max-width:520px;margin-left:auto;margin-right:auto;">AxonSDK is to edge compute what <code style="color:var(--accent)">httpx</code> is to HTTP — one client, any backend.</p>
   <div class="hero-ctas">
     <a class="btn-primary" href="#quickstart">Get started →</a>
-    <a class="btn-secondary" href="https://github.com/deyzho/axon" target="_blank">View on GitHub</a>
+    <a class="btn-secondary" href="https://github.com/deyzho/axonsdk" target="_blank">View on GitHub</a>
   </div>
   <div class="install-strip">
     <span class="prompt">$</span>
@@ -333,8 +333,8 @@
     <button class="copy-btn" onclick="copyInstall()">copy</button>
   </div>
   <div style="display:flex;gap:0.5rem;justify-content:center;flex-wrap:wrap;margin-top:1.5rem;">
-    <a href="https://github.com/deyzho/axon" target="_blank">
-      <img src="https://img.shields.io/github/stars/deyzho/axon?style=flat-square&color=f97316&label=stars" alt="GitHub stars" />
+    <a href="https://github.com/deyzho/axonsdk" target="_blank">
+      <img src="https://img.shields.io/github/stars/deyzho/axonsdk?style=flat-square&color=f97316&label=stars" alt="GitHub stars" />
     </a>
     <a href="https://pypi.org/project/axon" target="_blank">
       <img src="https://img.shields.io/pypi/v/axon?color=f97316&style=flat-square&label=pypi" alt="PyPI" />
@@ -342,8 +342,8 @@
     <a href="https://pypi.org/project/axon" target="_blank">
       <img src="https://img.shields.io/pypi/pyversions/axon?color=f97316&style=flat-square" alt="Python versions" />
     </a>
-    <a href="https://github.com/deyzho/axon/blob/master/LICENSE" target="_blank">
-      <img src="https://img.shields.io/github/license/deyzho/axon?color=f97316&style=flat-square" alt="License" />
+    <a href="https://github.com/deyzho/axonsdk/blob/master/LICENSE" target="_blank">
+      <img src="https://img.shields.io/github/license/deyzho/axonsdk?color=f97316&style=flat-square" alt="License" />
     </a>
   </div>
 </section>
@@ -367,7 +367,7 @@
         </ul>
         <div style="display:flex;gap:0.75rem;flex-wrap:wrap;">
           <a class="btn-primary" href="#router" style="font-size:0.9rem;padding:0.6rem 1.4rem;">See the router →</a>
-          <a class="btn-secondary" href="https://github.com/deyzho/axon" target="_blank" style="font-size:0.9rem;padding:0.6rem 1.4rem;">GitHub →</a>
+          <a class="btn-secondary" href="https://github.com/deyzho/axonsdk" target="_blank" style="font-size:0.9rem;padding:0.6rem 1.4rem;">GitHub →</a>
         </div>
       </div>
       <div>
@@ -910,7 +910,7 @@ router = <span class="obj">AxonRouter</span>(
           <li style="display:flex;gap:0.75rem;font-size:0.9rem;color:var(--muted)"><span style="color:var(--accent);font-weight:700;">✓</span> <code style="color:var(--accent);font-size:.85em">@axonsdk/mobile</code> — React Native hooks for iOS &amp; Android</li>
           <li style="display:flex;gap:0.75rem;font-size:0.9rem;color:var(--muted)"><span style="color:var(--accent);font-weight:700;">✓</span> <code style="color:var(--accent);font-size:.85em">@axonsdk/cli</code> — same <code style="color:var(--accent);font-size:.85em">axon</code> commands for JS projects</li>
         </ul>
-        <a class="btn-secondary" href="https://github.com/deyzho/axon-ts" target="_blank" style="font-size:0.9rem;padding:0.6rem 1.4rem;">View @axonsdk on GitHub →</a>
+        <a class="btn-secondary" href="https://github.com/deyzho/axonsdk-ts" target="_blank" style="font-size:0.9rem;padding:0.6rem 1.4rem;">View @axonsdk on GitHub →</a>
       </div>
       <div>
         <div class="code-block">
@@ -951,7 +951,7 @@ client.<span class="fn">onMessage</span>((msg) => {
     <h2>Start routing AI workloads today</h2>
     <p>One pip install. Any provider. Zero lock-in. Apache-2.0 licensed and fully open source.</p>
     <div class="hero-ctas">
-      <a class="btn-primary" href="https://github.com/deyzho/axon" target="_blank">View on GitHub →</a>
+      <a class="btn-primary" href="https://github.com/deyzho/axonsdk" target="_blank">View on GitHub →</a>
       <a class="btn-secondary" href="#quickstart">Quick start</a>
     </div>
     <div class="install-strip" style="margin-top:2.5rem;">
@@ -965,10 +965,10 @@ client.<span class="fn">onMessage</span>((msg) => {
 <!-- ── Footer ────────────────────────────────────────────────────────────── -->
 <footer>
   <div class="footer-links">
-    <a href="https://github.com/deyzho/axon" target="_blank">GitHub (Python)</a>
-    <a href="https://github.com/deyzho/axon-ts" target="_blank">GitHub (TypeScript)</a>
+    <a href="https://github.com/deyzho/axonsdk" target="_blank">GitHub (Python)</a>
+    <a href="https://github.com/deyzho/axonsdk-ts" target="_blank">GitHub (TypeScript)</a>
     <a href="https://pypi.org/project/axonsdk-py" target="_blank">PyPI</a>
-    <a href="https://github.com/deyzho/axon/blob/master/LICENSE" target="_blank">Apache-2.0</a>
+    <a href="https://github.com/deyzho/axonsdk/blob/master/LICENSE" target="_blank">Apache-2.0</a>
   </div>
   <p>AxonSDK · Provider-agnostic edge AI routing · Built with Python 3.11+</p>
 </footer>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,9 +71,9 @@ axon = "axon.cli.main:app"
 
 [project.urls]
 Homepage = "https://axonsdk.dev"
-Documentation = "https://github.com/deyzho/axon#readme"
-Repository = "https://github.com/deyzho/axon"
-Issues = "https://github.com/deyzho/axon/issues"
+Documentation = "https://github.com/deyzho/axonsdk#readme"
+Repository = "https://github.com/deyzho/axonsdk"
+Issues = "https://github.com/deyzho/axonsdk/issues"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/axon"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,7 +71,7 @@ axon = "axon.cli.main:app"
 
 [project.urls]
 Homepage = "https://axonsdk.dev"
-Documentation = "https://axonsdk.dev/docs"
+Documentation = "https://github.com/deyzho/axon#readme"
 Repository = "https://github.com/deyzho/axon"
 Issues = "https://github.com/deyzho/axon/issues"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "axonsdk-py"
-version = "0.1.11"
+version = "0.1.12"
 description = "Provider-agnostic edge compute SDK for AI workload routing"
 readme = "README.md"
 license = { text = "Apache-2.0" }
@@ -55,7 +55,7 @@ azure = [
 cloudflare = []   # httpx is already a core dependency
 fly = []          # httpx is already a core dependency
 all = [
-    "axon[blockchain,inference,cli,aws,gcp,azure]",
+    "axonsdk-py[blockchain,inference,cli,aws,gcp,azure]",
 ]
 dev = [
     "pytest>=8",

--- a/src/axon/__init__.py
+++ b/src/axon/__init__.py
@@ -9,6 +9,9 @@ Quickstart:
     deployment = await client.deploy(config)
 """
 
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _pkg_version
+
 from axon.client import AxonClient
 from axon.exceptions import AxonError, ConfigError, ProviderError
 from axon.router import AxonRouter
@@ -23,7 +26,10 @@ from axon.types import (
 )
 from axon.utils.retry import with_retry
 
-__version__ = "0.1.6"
+try:
+    __version__ = _pkg_version("axonsdk-py")
+except PackageNotFoundError:
+    __version__ = "0.0.0+unknown"
 
 __all__ = [
     "AxonClient",


### PR DESCRIPTION
## Summary

Weeks 1, 2, and 3 of the pre-launch remediation plan bundled into one PR. Releases as `axonsdk-py@0.1.12`.

### Week 1 — Shipping blockers
- **§1 `[all]` extra fix** — `pip install "axonsdk-py[all]"` was broken (self-referenced `axon[...]` instead of `axonsdk-py[...]`). Now resolves cleanly.
- **§2 Dynamic `__version__`** — read from `importlib.metadata.version("axonsdk-py")` instead of a hard-coded string. Previous 0.1.11 wheel shipped with stale `"0.1.6"`.
- **§7 `py.typed`** — empty PEP 561 marker, verified present in the built 0.1.12 wheel.
- **§3 CHANGELOG backfill** — entries for `0.1.10`, `0.1.11`, and the upcoming `0.1.12`; documented that `0.1.0`–`0.1.9` were pre-PyPI only.
- **§4 GitHub Release job** — mirrors the axon-ts repo's release automation.

### Week 2 — Credibility gaps
- **§9 Brand sweep** — README, CHANGELOG, CONTRIBUTING; prose "Axon" → "AxonSDK"; legal disclaimer.
- **§11 Docs URL repoint** — `pyproject.toml` `Documentation` URL from `https://axonsdk.dev/docs` (404) → `https://github.com/deyzho/axon#readme`.
- **§12 LICENSE** — added the missing `APPENDIX: How to apply the Apache License to your work.` section; should fix GitHub "License: Other" detection. PEP 639 SPDX migration deferred — see deferred summary.
- **§13 Dependabot** — `.github/dependabot.yml` with weekly pip + monthly github-actions.
- **§14 Community hygiene** — issue templates, PR template, CoC.
- **§15 Versioning policy** — `CONTRIBUTING.md` section codifying pre-1.0 SemVer and breaking-change docs requirements, plus a release checklist that reminds future-self not to manually edit `__version__`.

### Week 3 — Polish
- **§16 `pip-audit` step** — added to the CI test job. Freezes installed deps (filtering out `axonsdk-py` itself which isn't yet on PyPI for lookup), runs `pip-audit -r <frozen> --desc --strict`. Local: "No known vulnerabilities found" on the current dependency tree.
- **§17 ROADMAP** — full rewrite: v0.1.x marked shipped (2026-04) with 10 providers + SDK + CLI + security/supply-chain hardening; v0.2 Operator UX (Q3 2026), v0.3 Provider trust (Q4 2026), v0.4 LLM routing (Q1 2027), v1.0 Production-ready (Q2 2027) with 7 explicit acceptance criteria + release checklist.

## Test plan

### Local verification (Python 3.14 venv):
- [x] `pip install -e ".[all]" --dry-run` resolves cleanly — all six extras
- [x] `python -c "import axon; print(axon.__version__)"` → `0.1.12` (was `0.1.6`)
- [x] `python -m build --wheel` → `axonsdk_py-0.1.12-py3-none-any.whl` containing `axon/py.typed`
- [x] `pip-audit -r <frozen> --desc --strict` — "No known vulnerabilities found"
- [x] `ruff check src/axon` — clean
- [x] `mypy src/axon` strict — **clean, 27 files**
- [x] `pytest tests/` — **133 passed**
- [x] All YAML (dependabot + issue templates) valid
- [x] `pyproject.toml` parses cleanly

### Post-merge verification (release-time):
- [ ] Tag `v0.1.12` → CI publishes to PyPI via OIDC Trusted Publishing and auto-creates GitHub Release
- [ ] `pip install "axonsdk-py==0.1.12[all]"` installs all optional extras without resolver error
- [ ] Backfill: `gh release create v0.1.10 ...` and `gh release create v0.1.11 ...` with CHANGELOG sections as notes
- [ ] GitHub repo sidebar shows "Apache 2.0" (may require a cache refresh / push)
- [ ] Dependabot opens its first weekly PR

## Out of scope / deferred

See the end-of-execution summary for options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)